### PR TITLE
Added step to send API creating new issue if scan fails

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -161,4 +161,4 @@ runs:
         curl \
             -X POST 'https://asia-east2-sswlinkauditor-c1131.cloudfunctions.net/api/createReportIssue' \
             -H 'Content-Type: application/json' \
-            -d "{\"url\": \"${{ inputs.url }}\", \"dateReported\": \"$(date +"%Y-%m-%d %H:%M:%S")\", \"workflowId\": \"${{ github.run_id }}\", \"jobStatus\": \"${{ job.status }}\"}" \
+            -d "{\"url\": \"${{ inputs.url }}\", \"dateReported\": \"$(date +'%Y-%m-%d %H:%M:%S')\", \"repository\": \"${{ github.repository }}\", \"triggeringActor\": \"${{ github.actor }}\", \"repository_owner\": \"${{ github.repository_owner }}\", \"CodeAuditorToken\": \"${{ inputs.token }}\", \"workflowURL\": \"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}"

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,6 @@ runs:
         inputs=($INPUTS)
     - name: "SSW CodeAuditor - Check broken links and performance"
       shell: bash
-      continue-on-error: true
       run: |
         docker run sswconsulting/codeauditor --token ${{inputs.token}} --url ${{inputs.url}}
     - name: "Check if new broken links/code errors/code warnings has come up"
@@ -155,3 +154,11 @@ runs:
         echo "|   **Broken Links**          | ${{fromJson(steps.summaries.outputs.summariesOut).summary[0].totalUnique404}} |" >> $GITHUB_STEP_SUMMARY
         echo "|   **HTML Errors**           | ${{fromJson(steps.summaries.outputs.summariesOut).summary[0].htmlErrors}}     |" >> $GITHUB_STEP_SUMMARY
         echo "|   **HTML Warnings**         | ${{fromJson(steps.summaries.outputs.summariesOut).summary[0].htmlWarnings}}   |" >> $GITHUB_STEP_SUMMARY
+    - name: "Send issue report if scan fails"
+      shell: bash
+      if: ${{ failure() }}
+      run: |
+        curl \
+            -X POST 'https://asia-east2-sswlinkauditor-c1131.cloudfunctions.net/api/createReportIssue' \
+            -H 'Content-Type: application/json' \
+            -d '{"url": "${{inputs.url}}", "dateReported": "${{$(date +"%H:%M:%S %d-%m-%Y")}}"}' \

--- a/action.yml
+++ b/action.yml
@@ -161,4 +161,4 @@ runs:
         curl \
             -X POST 'https://asia-east2-sswlinkauditor-c1131.cloudfunctions.net/api/createReportIssue' \
             -H 'Content-Type: application/json' \
-            -d '{"url": "${{inputs.url}}", "dateReported": "${{$(date +"%H:%M:%S %d-%m-%Y")}}"}' \
+            -d "{\"url\": \"${{ inputs.url }}\", \"dateReported\": \"$(date +"%Y-%m-%d %H:%M:%S")\", \"workflowId\": \"${{ github.run_id }}\", \"jobStatus\": \"${{ job.status }}\"}" \


### PR DESCRIPTION
https://github.com/SSWConsulting/SSW.CodeAuditor/issues/875

- Added step to send an API to create new issue if the workflow run fails

<img width="961" alt="image" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/67776356/f15ecdb9-fe22-45bd-b93c-7296df8ea4f6">

**Figure: Sample generated report issue**